### PR TITLE
Update containers constraint

### DIFF
--- a/lrucache.cabal
+++ b/lrucache.cabal
@@ -1,5 +1,5 @@
 Name:                lrucache
-Version:             2.0
+Version:             2.1
 Synopsis:            a simple, pure LRU cache
 License:             BSD3
 License-file:        LICENSE
@@ -75,6 +75,6 @@ Library
 
   Build-depends:
         base >= 4 && < 5,
-        containers >= 0.2 && < 0.5
+        containers >= 0.2 && < 0.6
 
   GHC-options:  -Wall -O2


### PR DESCRIPTION
I propose that the lrucache containers constraint be updated to <0.6 so lrucache can be used easily with ghc-7.6.1. I have tested with this commit and it appears to compile correctly.
